### PR TITLE
Fix missing pagevars on newer Franklin.jl versions

### DIFF
--- a/utils.jl
+++ b/utils.jl
@@ -5,7 +5,7 @@ using Dates
 
 Plug in the list of blog posts contained in the `/blog/` folder.
 """
-function hfun_blogposts()
+@delay function hfun_blogposts()
     today = Dates.today()
     curyear = year(today)
     curmonth = month(today)


### PR DESCRIPTION
I'm running a copy of your code on my blog (https://huijzer.xyz):

https://github.com/rikhuijzer/huijzer.xyz/blob/8896af14419a3c04bcfb76da561ef5b4b898f6f1/utils.jl#L28-L77

However, it was broken for a few days since Franklin.jl changed in one of the more recent versions. All posts in the list showed `nothing`. It's now fixed with the help of @tlienart

This PR fixes the (soon to be) problem for you too.